### PR TITLE
deps: remove pin gRPC

### DIFF
--- a/activerecord-spanner-adapter.gemspec
+++ b/activerecord-spanner-adapter.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "google-cloud-spanner", "~> 2.18"
-  # Pin gRPC to 1.64.3, as 1.65 and 1.66 cause test runs to hang randomly.
-  spec.add_dependency "grpc", "1.64.3"
   spec.add_runtime_dependency "activerecord", [">= 6.1", "< 7.3"]
 
   spec.add_development_dependency "autotest-suffix", "~> 1.1"


### PR DESCRIPTION
Because it conflicts with other gems for Google Cloud (e.g. Cloudtasker)